### PR TITLE
Adjust daily instab broadcast

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -164,13 +164,13 @@ client.on("ready", () => {
 
 client.on("ready", () => {
   var job = new CronJob(
-    "0 1 2 * * *",
+    "0 1 0 * * *",
     () => {
       broadcastInstabilities();
     },
     null,
     true,
-    "Europe/Berlin"
+    "UTC"
   );
   job.start();
 });

--- a/bot.js
+++ b/bot.js
@@ -177,13 +177,16 @@ client.on("ready", () => {
 
 function sendHelp(channel) {
   channel.send(
-    "```md\n**HELP MENU** - Discretize [dT] bot \n \
-    - !today - shows today's instabilities\n \
-    - !tomorrow - shows tomorrow's instabilities\n \
-    - !in x - shows the instabilities in x days \n \
-    - !filter <level> <with|without> <instabs> \n \
-    - !t4s <in|at> <offset|date> \
-            ```"
+    `\`\`\`md
+    **HELP MENU** - Discretize [dT] bot
+    - !today - shows today's instabilities
+    - !tomorrow - shows tomorrow's instabilities
+    - !in x - shows the instabilities in x days
+    - !filter <level> <with|without> <instabs>
+    - !t4s <in|at> <offset|date>
+
+    Create a channel named #instabilities to receive daily updates on instabilities.
+    \`\`\``
   );
 }
 


### PR DESCRIPTION
This changes the timezone for the daily instab broadcast to UTC in order to match GW2 server time and not get messed up with summer/winter time. It also adds information about the broadcast feature to the help message.